### PR TITLE
Setting SHELL env var

### DIFF
--- a/bin/notes
+++ b/bin/notes
@@ -1,4 +1,5 @@
 #!/bin/bash
+SHELL=/bin/bash
 
 # Default directory to scan (change to your default directory if needed).
 NOTES_DIR="$HOME/Documents/.notes"

--- a/bin/notes
+++ b/bin/notes
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# Set the SHELL environment variable, fixes POSIX-incompatible shells
 SHELL=/bin/bash
 
 # Default directory to scan (change to your default directory if needed).


### PR DESCRIPTION
Small modification to force the SHELL environment variable to be `/bin/bash` to work with POSIX-incompatible shells like fish